### PR TITLE
Updates for Carto 0.9.4

### DIFF
--- a/lib/cartoRenderer.js
+++ b/lib/cartoRenderer.js
@@ -1108,7 +1108,8 @@ exports.processStyles = function(styles, assetsPath) {
     var propertyMatcher = /^\[([^\]]+)\]$/;
     flattened.forEach(function(ruleset) {
       ruleset.rules.forEach(function(rule) {
-        rule.value = rule.value.eval(env);
+        // Carto@0.9.3 uses eval(), 0.9.4 uses ev()
+        rule.value = (rule.value.eval || rule.value.ev).call(rule.value, env);
         
         // preload URIs as images
         if (rule.value.is === "uri") {
@@ -1147,6 +1148,18 @@ exports.processStyles = function(styles, assetsPath) {
           }
         }
       });
+
+      // deal with Carto@0.9.4 filters
+      if (ruleset.filters && ruleset.filters.filters) {
+        ruleset.filters = ruleset.filters.filters;
+        // this may not be the right thing to do in some complicated cases :\
+        __.each(ruleset.filters, function(filter) {
+          if (filter.key.is === "field") {
+            filter.key = filter.key.value;
+          }
+          filter.val = filter.val.toString();
+        });
+      }
     });
       
     processed = processed.concat(flattened);


### PR DESCRIPTION
Looks like there were a few breaking changes in Carto 0.9.4 that we never caught up with.
1. eval() vs. ev(), as mentioned in #62
2. Changes in the format of `filters` in the AST. Hopefully what I'm doing here is ultimately the right thing, though it might not be. Seems like the Carto AST has perhaps gotten a little more Mapnik specific.

Fixes #62. You may want to try playing with this, @hampelm/@prashtx.
