### PR TITLE
Update canvas dependency to be compatible with v1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
     - "0.12"
     - "0.10"
+    - "0.8"
 addons:
     apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: node_js
 node_js:
+    - "0.12"
     - "0.10"
-    - "0.8"
+addons:
+    apt:
+        packages:
+            - libcairo2-dev
+            - libjpeg8-dev
+            - libpango1.0-dev
+            - libgif-dev
+            - build-essential
+            - g++
 after_script: NODE_ENV=test istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "~0.2",
     "lodash": "~1.2",
-    "canvas": "~1.0",
+    "canvas": "^1.0",
     "proj4js": "~0.3.0",
     "proj4js-defs": ">=0.0.1",
     "carto": "~0.9.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "async": "~0.2",
     "lodash": "~1.2",
-    "canvas": "^1.0",
+    "canvas": ">=1.0 <2.0",
     "proj4js": "~0.3.0",
     "proj4js-defs": ">=0.0.1",
     "carto": "~0.9.3",


### PR DESCRIPTION
In #77, @waissbluth tripped over a dependency on an out-of-date version of Canvas that doesn’t build on the latest OS X :(

Rather than keep updating the dependency every time Canvas does a release, I’ve changed our dependency to work with any Canvas 1.x version. Since I believe Canvas uses semver, this *should* be safe. All our tests still pass (including new rendering tests in `bug-10-image-tests`).